### PR TITLE
Fiix dev setup

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -11,6 +11,26 @@ We recommend the use of `pip <http://pip.openplans.org/>`_ and `virtualenv
 in this and other Python projects. If you don't have them installed we
 recommend ``sudo easy_install pip`` and then ``sudo pip install virtualenv``.
 
+Bootstrapping a development environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Copy ``openemory/localsettings.py.dist`` to ``openemory/localsettings.py``
+  and configure any local settings: **DATABASES**,  **SECRET_KEY**,
+  **SOLR_**, **FEDORA_**,  customize **LOGGING**, etc.
+* Create a new virtualenv and activate it.
+* Install fabric: ``pip install fabric``
+* Use fabric to run a local build, which will install python dependencies in
+  your virtualenv, run unit tests, and build sphinx documentation: ``fab build``
+
+Deploy to QA and Production should be done using ``fab deploy``.
+
+After configuring your database, run syncdb::
+
+    python manage.py syncdb
+
+Use eulindexer to index repository content into your configured Solr instance.
+
+
 Configure the environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -84,7 +104,12 @@ To install python dependencies, cd into the repository checkout and::
 
   $ pip install -r pip-install-req.txt
 
-If you are a developer or are installing to a continuous ingration server
+*Note*: installation of some dependencies (i.e. django-tracking) requires
+that django settings are available. To install these manually, use this::
+
+  $ env DJANGO_SETTINGS_MODULE=openemory.settings pip install -r pip-install-after-config.txt
+
+If you are a developer or are installing to a continuous integration server
 where you plan to run unit tests, code coverage reports, or build sphinx
 documentation, you probably will also want to::
 
@@ -216,47 +241,47 @@ Set up iWatch to trigger notifications on folder where reports are created.
 
 Upgrade Notes
 =============
-Release 2.1.0 - Content Type Harmonization 
+Release 2.1.0 - Content Type Harmonization
 ------------------------------------------
 * mime type debugging
 * fixing styles
 
-Release 2.0.0 - New Content Type (Presentation) 
+Release 2.0.0 - New Content Type (Presentation)
 -----------------------------------------------
 * adding new content
 
-Release 1.9.0 - New Content Type (Poster) 
+Release 1.9.0 - New Content Type (Poster)
 -----------------------------------------
 * adding new content
 
-Release 1.8.0 - New Content Type (Report) 
+Release 1.8.0 - New Content Type (Report)
 -----------------------------------------
 * debugging conflicting policies in XACML
 
-Release 1.7.0 - New Content Type (Conference) 
+Release 1.7.0 - New Content Type (Conference)
 ---------------------------------------------
 
 
-Release 1.6.0 - New Content Type (Chapter) 
+Release 1.6.0 - New Content Type (Chapter)
 ------------------------------------------
 * run this script to cleanup journal articles (updated)
 
     $ python manage.py journal_title
 
 
-Release 1.5.0 - New Content Type (Book) 
+Release 1.5.0 - New Content Type (Book)
 ---------------------------------------
 * run this script to match all content models for articles and books
 
     $ python manage.py cmodel_cleanup
 
-Release 1.4.0 - Author Enhancements 
+Release 1.4.0 - Author Enhancements
 -----------------------------------
 * run this script to match all current journal titles with Sherpa Romeo
 
     $ python manage.py journal_title
 
-Release 1.3 - Pre Fedora Migration 
+Release 1.3 - Pre Fedora Migration
 ----------------------------------
 * run migrations for downtime
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,5 @@
 # file fabfile.py
-# 
+#
 #   Copyright 2010 Emory University General Library
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,7 @@ def all_deps():
     local('pip install -r pip-install-req.txt -r pip-dev-req.txt')
     if os.path.exists('pip-local-req.txt'):
         local('pip install -r pip-local-req.txt')
+    local("export DJANGO_SETTINGS_MODULE=%(project)s.settings && pip install -r pip-install-after-config.txt" % env)
 
 @task
 def test():
@@ -53,7 +54,7 @@ def test():
     app_list = ['accounts', 'common', 'publication', 'harvest']
     apps2test = ' '.join(map(lambda app: env.project + '.' + app +'.tests', app_list))
 
-    testing_cmd = 'python manage.py test --with-coverage --cover-package=%(project)s --cover-xml --with-xunit ' %env 
+    testing_cmd = 'python manage.py test --with-coverage --cover-package=%(project)s --cover-xml --with-xunit ' %env
     testing_cmd += apps2test
     local(testing_cmd)
 
@@ -334,9 +335,9 @@ def rm_old_builds(path=None, user=None, noinput=False):
             # get current and previous links so we don't remove either of them
             current = sudo('readlink current', user=env.remote_acct) if files.exists('current') else None
             previous = sudo('readlink previous', user=env.remote_acct) if files.exists('previous') else None
-            
+
         # split dir listing on newlines and strip whitespace
-        dir_items = [n.strip() for n in dir_listing.split('\n')] 
+        dir_items = [n.strip() for n in dir_listing.split('\n')]
         # regex based on how we generate the build directory:
         #   project name, numeric version, optional pre/dev suffix, optional revision #
         build_dir_regex = r'^%(project)s-[0-9.]+(-[A-Za-z0-9_-]+)?(-r[0-9]+)?$' % env
@@ -355,7 +356,7 @@ def rm_old_builds(path=None, user=None, noinput=False):
                     sudo('rm -rf %s' % dir, user=env.remote_acct)
         else:
             puts('No old build directories to remove')
- 
+
 @task
 def compare_localsettings(path=None, user=None):
     'Compare current/previous (if any) localsettings on the remote server.'

--- a/pip-install-req.txt
+++ b/pip-install-req.txt
@@ -19,7 +19,6 @@ python-dateutil
 xhtml2pdf
 PyPDF2
 python-magic
-#django-tracking
 django-widget-tweaks
 pyasn1
 progressbar
@@ -28,9 +27,12 @@ pdfminer==20110515
 requests
 pytz
 
-
 #version 1.0 breakes RDF parsing in python 2.x.  When bug is fixed requirement of 0.95 should be removed
 html5lib
 #latest version requires python 2.7 or 3.3+
 reportlab
 django-downtime
+
+# NOTE: django-tracking is not included here because install requires
+# django settings to be available.  See deploynotes for details.
+#django-tracking


### PR DESCRIPTION
I updated the deploy notes to document that `fab build` can be used to quickly bootstrap a development environment, and fixed the fab file so that it installs the "after-config" dependencies the same way locally as it does when it sets up a remote virtualenv for a deploy.  I also added some notes to the main pip install file and the manual install command to the deploynotes so hopefully it will be easier to find the solution the next time this comes up.