### PR TITLE
fixes metadata editing for ingest

### DIFF
--- a/openemory/publication/forms.py
+++ b/openemory/publication/forms.py
@@ -916,14 +916,14 @@ class ArticleEditForm(PublicationModsEditForm):
 
     publisher = forms.CharField(required=False,widget=forms.TextInput(attrs={'class': 'text'}), label='Publisher')
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,
@@ -995,14 +995,14 @@ class BookEditForm(PublicationModsEditForm):
 
     publisher = forms.CharField(required=False,widget=forms.TextInput(attrs={'class': 'text'}), label='Publisher')
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,
@@ -1075,14 +1075,14 @@ class ChapterEditForm(PublicationModsEditForm):
 
     publisher = forms.CharField(widget=forms.TextInput(attrs={'class': 'text'}), label='Publisher',required=True)
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,
@@ -1153,14 +1153,14 @@ class ConferenceEditForm(PublicationModsEditForm):
 
     publisher = forms.CharField(required=False,widget=forms.TextInput(attrs={'class': 'text'}), label='Publisher')
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,
@@ -1231,14 +1231,14 @@ class ReportEditForm(PublicationModsEditForm):
     publisher = forms.CharField(required=False,widget=forms.TextInput(attrs={'class': 'text'}), label='Publisher')
 
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,
@@ -1309,14 +1309,14 @@ class PosterEditForm(PublicationModsEditForm):
             help_text='Reason for reinstating this article')
 
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,
@@ -1387,14 +1387,14 @@ class PresentationEditForm(PublicationModsEditForm):
             help_text='Reason for reinstating this article')
 
 
-    _embargo_choices = [('','no embargo'),
+    _embargo_choices = [(slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
+                        ('','no embargo'),
                         ('6-months','6 months'),
                         ('12-months', '12 months'),
                         ('18-months', '18 months'),
                         ('24-months', '24 months'),
                         ('36-months', '36 months'),
                         ('48-months', '48 months'),
-                        (slugify(UNKNOWN_LIMIT["value"]), UNKNOWN_LIMIT["display"]),
                         (slugify(NO_LIMIT["value"]), NO_LIMIT["display"])]
 
     embargo_duration = forms.ChoiceField(choices=_embargo_choices,

--- a/openemory/publication/templates/publication/edit.html
+++ b/openemory/publication/templates/publication/edit.html
@@ -265,15 +265,6 @@
            version = 'pdf';
 
          var policy = copyright_policy[version];
-         if (policy.archiving) {
-           $('#publisher-copyright-status-value')
-             .text(policy.archiving)
-             .attr('class', policy.archiving);
-         } else {
-           $('#publisher-copyright-status-value')
-             .text('unknown')
-             .attr('class', 'unknown');
-         }
 
          var restrictions = $('#publisher-copyright-restrictions-items');
          restrictions.html('');
@@ -446,10 +437,6 @@
         {% if article.descMetadata.content.genre != "Report" and article.descMetadata.content.genre != "Poster"  and article.descMetadata.content.genre != "Presentation" %}
         {% include "publication/snippets/edit_field.html" with field=form.version divclass="formThird" %}
         {% if perms.publication.review_article %}
-              <div id="publisher-copyright-status" class="formThird">
-                <label>Archiving</label>
-                <div id="publisher-copyright-status-value" class="unknown">unknown</div>
-              </div>
               <!-- inline style here should be overridden by jq toggle() on load -->
               <div id="publisher-copyright-restrictions" class="clearLeft"
                   style='display:none'>
@@ -673,12 +660,12 @@
         {% include "publication/snippets/edit_field.html" with field=form.subforms.copyright divclass="formWhole" %}
 
         {#  AdminNote  #}
-        {%if perms.publication.view_admin_metadata %}
+        {% if perms.publication.view_admin_metadata or category_id == 'ingest' %}
             {% include "publication/snippets/edit_field.html" with field=form.subforms.admin_note.text divclass="formWhole"%}
         {% endif %}
 
       </div><!-- /formWrapper -->
-      {% if perms.publication.review_article %}
+      {% if perms.publication.review_article and category_id == 'edit' %}
           <div id="mark-reviewed" class="formWhole">
           {% if article.provenance.content.review_event %}
             <p class="info">{{ article.provenance.content.review_event.detail }} on

--- a/openemory/publication/templates/publication/snippets/edit_submit.html
+++ b/openemory/publication/templates/publication/snippets/edit_submit.html
@@ -11,7 +11,7 @@
       {% if not article.is_published %}
       {#  <a class="tip" title="Save changes and publish this work the site so it will be publicly visible."></a> #}
       {% endif %}
-      {% if perms.publication.review_article %} {# admin save + review button #}
+      {% if perms.publication.review_article and category_id == 'edit' %} {# admin save + review button #}
          <input type="submit" name="review-record" value="Review" class="submit"/>
 {#         <a class="tip" title="Save changes and return to review list; work will remain {% if article.is_published %}published{% else %}unpublished{% endif %} on the site."></a> #}
       {% endif %}


### PR DESCRIPTION
- openemory/publication/forms.py (changes the default to Unknown for embargo fields)
- openemory/publication/templates/publication/edit.html (adjusts permissions and fields based whether it is a form after ingest or just editing metadata)
- openemory/publication/templates/publication/snippets/edit_submit.html (adjusts permissions to hide review button for manual ingest)
- openemory/publication/views.py (adds functionality to pass parameter 'category' after ingest, default is set to edit)