### PR TITLE
Removes footer elements and replaces one link (#177).

### DIFF
--- a/templates/site_base.html
+++ b/templates/site_base.html
@@ -475,10 +475,6 @@ www.352media.com
           <li class="stat-val">{{ ARTICLE_STATISTICS.year_downloads|intcomma }}</li>
           <li class="stat-label">Download{{ ARTICLE_STATISTICS.year_downloads|pluralize }} This Year</li>
         </ul>
-        <ul class="site-stat">
-          <li class="stat-val">{{ ACCOUNT_STATISTICS.total_users|intcomma }}</li>
-          <li class="stat-label">Faculty Profile{{ ACCOUNT_STATISTICS.total_users|pluralize }}</li>
-        </ul>
       </div>
 
       {% endblock %}
@@ -491,7 +487,7 @@ www.352media.com
             Atlanta, GA
             30322-2870<br /> (404)
             727-6861<br />
-            <a href="http://web.library.emory.edu/about/privacy-policy/index.html" target="_blank">Privacy Policy</a>
+            <a href="https://libraries.emory.edu/about/policies/emory-libraries-privacy-policy" target="_blank">Privacy Policy</a>
             | <a href="{{ sitepages.terms.url }}">Terms &amp; Conditions</a></p>
 
             {% if SW_VERSION %}  {# FIXME: better place for version? #}
@@ -502,9 +498,6 @@ www.352media.com
         <div class="rightCol">
           <a href="http://sco.library.emory.edu/about/staff.html" target="_blank" class="button">
             <span>Contact Us</span>
-          </a>
-          <a href="{% url 'publication:summary' %}" class="button">
-            <span>Recent and Popular Items</span>
           </a>
         </div>
 


### PR DESCRIPTION
Removes two interpolative elements that are no longer reliably delivering (L#478-481 and L#506-508), and updates the link to the privacy policy (L#490).

Addresses https://app.zenhub.com/workspaces/legacy-systems-5d793aeb3859ca0001801253/issues/gh/emory-libraries/openemory/177 . 