### PR TITLE
Updates and hides requested links (#190).

### DIFF
--- a/sitemedia/css/structure.css
+++ b/sitemedia/css/structure.css
@@ -99,6 +99,9 @@ img.floatRight {
   color: #fff;
 }
 .HeaderRight .links {
+  visibility: hidden;
+}
+/*.HeaderRight .links {
   height: 25px;
   display: block;
   width: 100%;
@@ -114,7 +117,7 @@ img.floatRight {
   margin-left: 14px;
   line-height: 25px;
   text-transform: uppercase;
-}
+}*/
 .User {
   height: 58px;
   display: block;

--- a/templates/site_base.html
+++ b/templates/site_base.html
@@ -84,8 +84,8 @@ www.352media.com
           <li><a href="http://web.library.emory.edu/">Woodruff</a></li>
           <li><a href="http://business.library.emory.edu/">Business</a></li>
           <li><a href="http://health.library.emory.edu/">Health Sciences</a></li>
-          <li><a href="http://law.emory.edu/">Law</a> </li>
-          <li><a href="http://marbl.library.emory.edu/">MARBL</a></li>
+          <li><a href="https://library.law.emory.edu/">Law</a> </li>
+          <li><a href="https://libraries.emory.edu/rose">Rose</a></li>
           <li><a href="http://oxford.emory.edu/Library/">Oxford College</a></li>
           <li><a href="http://www.pitts.emory.edu/">Theology</a></li>
         </ul>


### PR DESCRIPTION
- sitemedia/css/structure.css: per @eporter23, I have hidden the links instead of removing their html (L#102).
- templates/site_base.html: 
  - L#87: swapping out to the new law library site.
  - L#88: switched the link to the true endpoint of the MARBL redirect, as well as changed MARBL label to Rose.

Addresses https://app.zenhub.com/workspaces/legacy-systems-5d793aeb3859ca0001801253/issues/gh/emory-libraries/openemory/190